### PR TITLE
Adds `max-width: 100%;` to logo

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -175,5 +175,6 @@ footer {
 }
 
 .img-logo {
+  max-width: 100%;
   width: 500px;
 }


### PR DESCRIPTION
By limiting the maximum width of the logo, we can ensure that it never overflows the visible area.

Fixes #2.